### PR TITLE
Set scaleShowLabels to true to be consistent with chart.js.

### DIFF
--- a/lib/chart.js
+++ b/lib/chart.js
@@ -58,7 +58,7 @@ var LineDefaults = proto.Line.defaults = {
   scaleLineWidth : 1,
 
   //Boolean - Whether to show labels on the scale
-  scaleShowLabels : false,
+  scaleShowLabels : true,
 
   //Interpolated JS string - can access value
   scaleLabel : "<%=value%>",


### PR DESCRIPTION
Hey, changed the default value of `scaleShowLabels` for the line charts to be more consistent with `chart.js`.
