### PR TITLE
Define tmpl, so creating a Line chart doesn't fail

### DIFF
--- a/lib/line.js
+++ b/lib/line.js
@@ -2,6 +2,7 @@ var utils = require('./utils'),
     calculateScale = utils.calculateScale,
     calculateOffset = utils.calculateOffset,
     getDecimalPlaces = utils.getDecimalPlaces,
+    tmpl = utils.tmpl,
     MAX_VALUE = Number.MAX_VALUE,
     MIN_VALUE = Number.MIN_VALUE;
 


### PR DESCRIPTION
Right now, using the `scaleOverride` and the `scaleSteps` options produces the following error:

``` js
ReferenceError: tmpl is not defined
  at new Line (/Users/alioudiallo/src/misc/reporter/node_modules/nchart/lib/line.js:65:11)
  at Chart.proto.Line (/Users/alioudiallo/src/misc/reporter/node_modules/nchart/lib/chart.js:36:10)
  at Object.module.exports.LineGraph (/Users/alioudiallo/src/misc/reporter/helper.coffee:60:3, <js>:70:20)
  at /Users/alioudiallo/src/misc/reporter/daily_mood.coffee:36:3, <js>:60:19
  at Function._.each._.forEach (/Users/alioudiallo/src/misc/reporter/node_modules/underscore/underscore.js:87:22)
  at Object.<anonymous> (/Users/alioudiallo/src/misc/reporter/daily_mood.coffee:20:1, <js>:37:5)
  at Object.<anonymous> (/Users/alioudiallo/src/misc/reporter/daily_mood.coffee:1:1, <js>:63:4)
  at Module._compile (module.js:456:26)
```

This pull defines `tmpl` and fixes the issue.
